### PR TITLE
Integration of new PoliTO Liqo Dashboard

### DIFF
--- a/playbook/dashboard_deploy.yaml
+++ b/playbook/dashboard_deploy.yaml
@@ -5,7 +5,7 @@
   gather_facts: true
   become: true
   pre_tasks:
-    - name : Get k3s version
+    - name: Get k3s version
       ansible.builtin.command: k3s --version
       register: k3s_version_output
       changed_when: false
@@ -19,8 +19,8 @@
       when: k3s_version_output.rc == 0
 
   roles:
+    - role: liqo-dashboard
     - role: k3s-dashboard
       when: k3s_version_output.rc == 0 and dashboard_check_output.rc != 0
     - role: default_page
       when: k3s_version_output.rc == 0
-    - role: liqo-dashboard

--- a/playbook/roles/liqo-dashboard/files/ingress.yaml
+++ b/playbook/roles/liqo-dashboard/files/ingress.yaml
@@ -1,23 +1,36 @@
 ---
-
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: liqo-dashboard-backend-ingress
+  spec:
+    ingressClassName: nginx
+    rules:
+    - http:
+        paths:
+        - backend:
+            service:
+              name: liqo-dashboard-backend-service
+              port:
+                number: 8089
+          path: /api
+          pathType: Prefix
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: liqo-dashboard
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^(/liqo)$ $1/ redirect;
+  name: liqo-dashboard-frontend-ingress
 spec:
   ingressClassName: nginx
   rules:
   - http:
       paths:
-      - path: /liqo(/|$)(.*)
-        pathType: Prefix
-        backend:
+      - backend:
           service:
-            name: liqo-dashboard
+            name: liqo-dashboard-frontend-service
             port:
-              number: 443
+              number: 8080
+        path: /liqo(/|$)(.*)
+        pathType: Prefix

--- a/playbook/roles/liqo-dashboard/tasks/main.yaml
+++ b/playbook/roles/liqo-dashboard/tasks/main.yaml
@@ -1,30 +1,36 @@
 ---
-# -----------------------------
 # This Ansible playbook installs the Liqo Dashboard on the cluster
-# -----------------------------
 
 - name: Clone LiqoDash repository
-  git:
-    repo: 'https://github.com/liqotech/dashboard'
+  ansible.builtin.git:
+    repo: 'https://github.com/zankro/liqo-dashboard-test.git'
     dest: '/tmp/dashboard'
-    version: 'master'
+    version: 'main'
 
-- name: Install LiqoDash with Helm 
-  shell: | 
-    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    helm install liqo-dashboard /tmp/dashboard/kubernetes/dashboard_chart
-    
+- name: Install LiqoDash with Helm using shell command
+  ansible.builtin.shell: |
+    helm install liqo-dashboard /tmp/dashboard/chart \
+      --kubeconfig /etc/rancher/k3s/k3s.yaml \
+      --namespace default \
+      --set backend.imageName="andreacv98/liqo-dashboard-backend" \
+      --set frontend.imageName="andreacv98/liqo-dashboard-frontend" \
+      --set image.tag="0.0.1"
+
+- name: Delete default LiqoDash ingress if exists
+  ansible.builtin.shell: |
+    kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml delete ingress liqo-dashboard-ingress --ignore-not-found=true
+
 - name: Copy Ingress Configuration File in home directory
   ansible.builtin.copy:
     src: ingress.yaml
     dest: "./liqo-ingress.yaml"
+    mode: "0644"
 
-- name: Apply Ingress Configuration File
-  ansible.builtin.command: kubectl apply -f liqo-ingress.yaml 
+- name: Apply Ingress Configuration YAML File
+  ansible.builtin.shell: |
+    kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -f ./liqo-ingress.yaml
 
-  
-
-- name: Clean Ingress Configuration File
-  file:
+- name: Delete Ingress Configuration File Previously Copied
+  ansible.builtin.file:
     path: liqo-ingress.yaml
     state: absent


### PR DESCRIPTION
Integration of the Liqo Dashboard developed by PoliTO's students (https://github.com/zankro/liqo-dashboard-test).

The images are rebuilt and fixed to work with x86_64 architectures (official Chart docker images only compatible with ARM architecture).