### PR TITLE
Checking git installation before cloning liqo repo

### DIFF
--- a/playbook/roles/liqo-dashboard/tasks/main.yaml
+++ b/playbook/roles/liqo-dashboard/tasks/main.yaml
@@ -1,6 +1,14 @@
 ---
 # This Ansible playbook installs the Liqo Dashboard on the cluster
 
+- name: Ensure git is installed
+  ansible.builtin.shell: |
+    if ! command -v git > /dev/null 2>&1; then
+      sudo apt update && sudo apt install -y git
+    fi
+  args:
+    executable: /bin/bash
+
 - name: Clone LiqoDash repository
   ansible.builtin.git:
     repo: 'https://github.com/zankro/liqo-dashboard-test.git'


### PR DESCRIPTION
A new task is added to check if git is installed and if not, it installs git before cloning liqo repository.