### PR TITLE
Editing access to kubevirt dashboard

### DIFF
--- a/playbook/roles/default_page/files/defaultpage-ingress.yaml
+++ b/playbook/roles/default_page/files/defaultpage-ingress.yaml
@@ -7,16 +7,27 @@ metadata:
     # Use the nginx ingress controller
     kubernetes.io/ingress.class: nginx
 
-    # Rewrite URLs such as /default/index.html into /index.html
+    # Rewrite URLs
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 
-    # Redirect /default to /default/ to ensure proper trailing slash
+    # Remove any redirect for root path
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      # Only redirect /default without trailing slash
       rewrite ^(/default)$ $1/ redirect;
+
 spec:
   rules:
     - http:
         paths:
+          # Match the root path exactly
+          - path: /()(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: defaultpage-service
+                port:
+                  number: 8000
+          # Keep the /default path for backward compatibility
           - path: /default(/|$)(.*)
             pathType: Prefix
             backend:

--- a/playbook/roles/default_page/files/index.html
+++ b/playbook/roles/default_page/files/index.html
@@ -42,9 +42,26 @@
             <p class="col text-center fw-medium"><a href="/prometheus/graph" title="Prometheus dashboard">Prometheus Dashboard</a></p>
         </div>
         <div class="row">
-            <p class="col text-center fw-medium"><a href="http://kubevirt.local" title="Kubvirt Manager">Kubvirt Dashboard</a></p>
+            <p class="col text-center fw-medium"><a href="#" id="kubevirt-nodeport" title="KubeVirt Manager">KubeVirt Dashboard</a></p>
         </div>
     </main>
+
+    <script>
+        // Get the KubeVirt link element
+        const kubevirtLink = document.getElementById('kubevirt-nodeport');
+        
+        // Function to update the KubeVirt link with the node IP and port
+        function updateKubeVirtLink() {
+            // Get the hostname (IP address)
+            const hostname = window.location.hostname;
+            
+            // Set the link URL to use the hostname and the NodePort
+            kubevirtLink.href = `http://${hostname}:30880`;
+        }
+        
+        // Call the function when the page loads
+        window.onload = updateKubeVirtLink;
+    </script>
  
 </body>
 

--- a/playbook/roles/default_page/tasks/defaultpage.yaml
+++ b/playbook/roles/default_page/tasks/defaultpage.yaml
@@ -23,10 +23,19 @@
     src: defaultpage-ingress.yaml
     dest: "./defaultpage-ingress.yaml"
 
+- name: Delete existing defaultPage Ingress if it exists
+  ansible.builtin.command: kubectl delete ingress defaultpage-ingress -n default --ignore-not-found=true
+  register: delete_result
+  
+- name: Wait for ingress deletion to complete
+  ansible.builtin.pause:
+    seconds: 3
+  when: delete_result.rc == 0 and delete_result.stdout != ""
+
 - name: Apply Deployment File
   ansible.builtin.command: kubectl apply -f defaultpage-deployment.yaml
 
-- name: Apply DefaultPage Ingress
+- name: Apply Ingress Configuration File
   ansible.builtin.command: kubectl apply -f defaultpage-ingress.yaml
 
 - name: Clean Deployment File

--- a/playbook/roles/kubevirt-setup/files/ingress.yaml
+++ b/playbook/roles/kubevirt-setup/files/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kubevirt-manager
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - host: kubevirt.local

--- a/playbook/roles/kubevirt-setup/files/service.yaml
+++ b/playbook/roles/kubevirt-setup/files/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubevirt-manager
+  namespace: kubevirt-manager
+  labels:
+    app: kubevirt-manager
+    kubevirt-manager.io/version: 1.5.0
+spec:
+  type: NodePort
+  selector:
+    app: kubevirt-manager
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      nodePort: 30880 

--- a/playbook/roles/kubevirt-setup/tasks/main.yml
+++ b/playbook/roles/kubevirt-setup/tasks/main.yml
@@ -88,7 +88,7 @@
 - name: "Create Service for KubeVirt Manager UI"
   kubernetes.core.k8s:
     state: present
-    src: "https://raw.githubusercontent.com/kubevirt-manager/kubevirt-manager/main/kubernetes/service.yaml"
+    src: "roles/kubevirt-setup/files/service.yaml"
   tags:
     - kubevirt
 
@@ -99,20 +99,13 @@
   tags:
     - kubevirt
 
-# We tried exposing the KubeVirt Manager UI under a subpath (e.g., /kubevirt), like the other dashboards, 
-# but it caused routing issues and conflicts with existing UIs.
-# To avoid these conflicts and simplify access, the KubeVirt UI is exposed
-# through a dedicated hostname (kubevirt.local) and we need to add the
-# corresponding mapping to /etc/hosts via Ansible.
-# This way, the dashboard remains isolated and does not interfere with other services.
-- name: "Add kubevirt.local in /etc/hosts"
-  become: true
-  lineinfile:
-    path: /etc/hosts
-    regexp: '^.*kubevirt.local'
-    line: "{{ ansible_default_ipv4.address }} kubevirt.local"
-    state: present
+- name: "Wait for KubeVirt Manager service to be available"
+  shell: |
+    kubectl get svc -n kubevirt-manager kubevirt-manager -o jsonpath='{.spec.ports[0].nodePort}'
+  register: kubevirt_nodeport
+  retries: 10
+  delay: 5
+  until: kubevirt_nodeport.stdout != ""
   tags:
-      - kubevirt
-
+    - kubevirt
 

--- a/setup/edge-pc-local-setup.sh
+++ b/setup/edge-pc-local-setup.sh
@@ -129,7 +129,7 @@ print_end_message() {
         write_separate_line
         write_row "Dashboard" "URL" "Password"
         write_separate_line
-        write_row "General" "http://$1/default" "Not required"
+        write_row "General" "http://$1" "Not required"
         write_separate_line
         write_row "K3S" "http://$1/k3sdashboard" "Check README.md"
         write_separate_line
@@ -137,7 +137,7 @@ print_end_message() {
         write_separate_line
         write_row "Prometheus" "http://$1/prometheus/graph" "Not required"
         write_separate_line
-        write_row "KubeVirt" "http://kubevirt.local" "Not required"
+        write_row "KubeVirt" "http://$1:30880" "Not required"
         write_separate_line
 }
 


### PR DESCRIPTION
The ability to make a subpath for kubevirt dashboard is not available, yet.
So I made it available through NodePort service and it is linked on the ingress webpage.
The ingress webpage is also accessible on only the IP address of the node. (It was available on IP_ADDRESS/default) 