### PR TITLE
Bugfix for prometheus and kubevirt dashboards and Adding cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ The second option could be useful for master node initialization, or if the user
 
 Once the installation terminates, a **web page** keeping the links to all dashboards present in the edge node is available at: __*http(s)://{edge node IP address}*__.
 
+### Cleaning up the installation
+
+If you need to uninstall all components and restore your system to its pre-installation state, a cleanup script is provided:
+
+```bash
+# Download the cleanup script
+curl https://raw.githubusercontent.com/netgroup-polito/edge-infrastructure-ansible/main/setup/edge-pc-cleanup.sh > edge-pc-cleanup.sh
+chmod +x edge-pc-cleanup.sh
+
+# Run the cleanup script
+sudo ./edge-pc-cleanup.sh
+```
+
+The cleanup script will:
+1. Uninstall K3s and remove its data directories
+2. Remove Helm, virtctl, and kubectl configurations
+3. Remove Ansible and Helm repositories
+4. Optionally remove the management user (mgmt)
+5. Clean up temporary files and system packages
+6. Reset IP tables rules
+
+The script will prompt for confirmation before making changes and includes options to customize the cleanup process.
+
 ## Manual installation (using individual ansible files, for expert users)
 Manual install is based on multiple Ansible files, which need to be launched individually.
 This provides more flexibility in the installation process, e.g., by enabling to customize some parameters (e.g., you can install a software locally or on a remote machine), and by selecting exactly which software has to be installed.
@@ -153,6 +176,21 @@ In order, it will:
 In the absence of an ingress for grafana, it is possible to expose and access grafana via nodeport with the following command:
 
 ```sudo kubectl expose service prometheus-grafana --type=NodePort --name=grafana-ext --target-port=3000 -n monitoring```
+
+The reason why we could not use the existing ingress is that:
+
+* Every service in the cluster has different routing requirements and path configurations  
+* The existing ingress might have other path configurations or annotations which would be in conflict with the requirements of Prometheus  
+* Prometheus has specific timeout settings and SSL configurations which might not be compatible with other services  
+* Having a separate ingress for Prometheus facilitates better isolation and easier management of its specific requirements without affecting other services  
+
+Having such separation of concerns between different ingress resources is commonly used in Kubernetes to:
+
+* Cleanly keep service boundaries intact  
+* Enable service-specific configurations  
+* Simplify managing and debugging each service separately  
+* Prevent configuration conflicts between various services  
+
 
 ### Grafana configuration
 

--- a/playbook/roles/ddns/tasks/main.yaml
+++ b/playbook/roles/ddns/tasks/main.yaml
@@ -33,9 +33,18 @@
         state: latest
         update_cache: true
 
-    - name: Install Kubernetes Python module
+    - name: Install the Python client for kubernetes from apt
+      apt:
+        name: python3-kubernetes
+        state: present
+      register: apt_install_result
+      ignore_errors: true
+
+    - name: Install the python client for Kubernetes using pip with system-packages flag (this task is executed when the installation from apt fails)
       pip:
         name: kubernetes
+        extra_args: --break-system-packages
+      when: apt_install_result is failed
 
     - name: Create data directory on host
       file:

--- a/playbook/roles/energymon/files/prometheus-ingress.yaml
+++ b/playbook/roles/energymon/files/prometheus-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-direct
+  namespace: monitoring
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /prometheus
+        pathType: Prefix
+        backend:
+          service:
+            name: prometheus-operated
+            port:
+              number: 9090 

--- a/playbook/roles/energymon/files/values.yaml
+++ b/playbook/roles/energymon/files/values.yaml
@@ -49,6 +49,8 @@ prometheus:
     ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$2
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        rewrite ^(/prometheus)$ $1/ redirect;
 
     hosts: []
     # hosts:
@@ -78,8 +80,23 @@ prometheus:
   prometheusSpec:
     ## External URL at which Prometheus will be reachable.
     ##
-    externalUrl: ""
+    externalUrl: "/prometheus"
     ## Prefix used to register routes, overriding externalUrl route.
     ## Useful for proxies that rewrite URLs.
     ##
-    routePrefix: /
+    routePrefix: "/prometheus"
+    ## Port on which Prometheus is listening
+    ##
+    listenLocal: false
+    portName: http-web
+    containers:
+      - name: prometheus
+        ports:
+          - containerPort: 9090
+            name: http-web
+    service:
+      port: 9090
+      targetPort: 9090
+    # Ensure Prometheus is configured for the path
+    web:
+      path: "/prometheus"

--- a/playbook/roles/energymon/tasks/prometheus-grafana.yaml
+++ b/playbook/roles/energymon/tasks/prometheus-grafana.yaml
@@ -1,4 +1,3 @@
-
 - name: Check if prometheus and grafana are already installed
   shell: helm --kubeconfig /etc/rancher/k3s/k3s.yaml status {{ helm.prometheus_release_name }} -n monitoring
   register: helm_prometheus_exists_result
@@ -55,3 +54,46 @@
     kubectl patch prometheus prometheus-kube-prometheus-prometheus -n monitoring --type=json
     -p '[{"op": "replace", "path": "/spec/podMonitorSelector", "value": {}}, {"op": "replace", "path": "/spec/serviceMonitorSelector", "value": {}}]'
   when: helm_prometheus_exists_result.rc != 0
+
+# Configure Prometheus ingress always (both for new and existing installations)
+- name: Check if Prometheus monitoring namespace exists
+  shell: kubectl get namespace monitoring
+  register: monitoring_ns_exists
+  ignore_errors: true
+
+# Configure Prometheus to use correct path
+- name: Patch Prometheus CR to use /prometheus prefix
+  command: >
+    kubectl patch prometheus -n monitoring prometheus-kube-prometheus-prometheus --type=json
+    -p '[{"op":"replace","path":"/spec/externalUrl","value":"/prometheus"},{"op":"replace","path":"/spec/routePrefix","value":"/prometheus"}]'
+  ignore_errors: true
+  when: monitoring_ns_exists.rc == 0
+
+# Delete existing Prometheus ingress
+- name: Delete existing Prometheus ingress
+  command: kubectl delete ingress prometheus-kube-prometheus-prometheus -n monitoring
+  ignore_errors: true
+  when: monitoring_ns_exists.rc == 0
+
+# Add direct ingress for Prometheus
+- name: Copy prometheus ingress yaml
+  ansible.builtin.copy:
+    src: prometheus-ingress.yaml
+    dest: "./prometheus-ingress.yaml"
+  when: monitoring_ns_exists.rc == 0
+
+- name: Apply Prometheus direct ingress
+  command: kubectl apply -f prometheus-ingress.yaml
+  when: monitoring_ns_exists.rc == 0
+
+# Restart Prometheus pod to pick up configuration changes
+- name: Restart Prometheus pod
+  shell: kubectl delete pods -n monitoring -l app=prometheus --field-selector=status.phase=Running
+  ignore_errors: true
+  when: monitoring_ns_exists.rc == 0
+
+- name: Clean prometheus ingress file
+  file: 
+    path: prometheus-ingress.yaml 
+    state: absent
+  when: monitoring_ns_exists.rc == 0

--- a/playbook/roles/kubevirt-prereq/tasks/main.yaml
+++ b/playbook/roles/kubevirt-prereq/tasks/main.yaml
@@ -11,13 +11,26 @@
   tags:
     - kubevirt
 
-- name: Ensure python3-kubernetes is installed on localhost
+- name: Try to install python3-kubernetes using apt
+  become: true
+  package:
+    name: python3-kubernetes
+    state: present
+  register: apt_install_result
+  ignore_errors: true
+  delegate_to: localhost
+  tags:
+    - kubevirt
+
+- name: Ensure python3-kubernetes is installed using pip with system-packages flag
   pip:
     name: kubernetes
     state: present
+    extra_args: --break-system-packages
   become: true
   vars:
     ansible_python_interpreter: /usr/bin/python3
+  when: apt_install_result is failed
   delegate_to: localhost
   tags:
     - kubevirt

--- a/setup/edge-pc-cleanup.sh
+++ b/setup/edge-pc-cleanup.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+cat << "EOF"
+  _____    _             _____ _                               
+ | ____|__| | __ _  ___ / ____| | ___  __ _ _ __  _   _ _ __   
+ |  _| / _` |/ _` |/ _ \ |    | |/ _ \/ _` | '_ \| | | | '_ \  
+ | |__| (_| | (_| |  __/ |____| |  __/ (_| | | | | |_| | |_) | 
+ |_____\__,_|\__, |\___|\_____|_|\___|\__,_|_| |_|\__,_| .__/  
+             |___/                                      |_|     
+EOF
+
+echo "This script will remove all components installed by the edge-infrastructure-ansible project."
+echo "Please make sure to backup any important data before proceeding."
+echo "You will be prompted for confirmation before any destructive actions."
+echo
+
+# Check if script is running with sudo
+if [ "$EUID" -ne 0 ]; then
+  echo "This script needs sudo privileges, please run: sudo ./$(basename $0)"
+  exit 1
+fi
+
+# Ask for confirmation
+read -p "Are you sure you want to proceed with the cleanup? (y/n): " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  echo "Cleanup aborted."
+  exit 0
+fi
+
+echo "Starting cleanup process..."
+echo "--------------------------"
+
+# Step 1: Uninstall K3s
+echo "[1/12] Uninstalling K3s..."
+if [ -f /usr/local/bin/k3s-uninstall.sh ]; then
+  /usr/local/bin/k3s-uninstall.sh
+  echo "✓ K3s uninstalled successfully."
+else
+  echo "K3s uninstall script not found, skipping."
+fi
+
+# Step 2: Remove K3s data directories
+echo "[2/12] Removing K3s data directories..."
+rm -rf /etc/rancher/k3s /var/lib/rancher/k3s
+echo "✓ K3s data directories removed."
+
+# Step 3: Remove Helm
+echo "[3/12] Removing Helm..."
+rm -rf /usr/local/bin/helm ~/.helm ~/.config/helm
+echo "✓ Helm removed."
+
+# Step 4: Remove virtctl (KubeVirt CLI)
+echo "[4/12] Removing virtctl (KubeVirt CLI)..."
+rm -f /usr/local/bin/virtctl
+echo "✓ virtctl removed."
+
+# Step 5: Remove kubectl configuration
+echo "[5/12] Removing kubectl configuration..."
+rm -rf ~/.kube
+echo "✓ kubectl configuration removed."
+
+# Step 6: Remove Ansible repository
+echo "[6/12] Removing Ansible repository..."
+rm -f /etc/apt/sources.list.d/ansible-*.list
+echo "✓ Ansible repository removed."
+
+# Step 7: Remove Helm repository
+echo "[7/12] Removing Helm repository..."
+rm -f /etc/apt/sources.list.d/helm-*.list
+echo "✓ Helm repository removed."
+
+# Step 8: Remove management user
+echo "[8/12] Checking for management user..."
+if id "mgmt" &>/dev/null; then
+  read -p "Do you want to remove the 'mgmt' user? (y/n): " remove_user
+  if [[ "$remove_user" =~ ^[Yy]$ ]]; then
+    userdel -r mgmt
+    echo "✓ Management user removed."
+  else
+    echo "Skipping management user removal."
+  fi
+else
+  echo "Management user not found, skipping."
+fi
+
+# Step 9: Remove temporary files
+echo "[9/12] Removing temporary files..."
+rm -rf /home/mgmt/edge-infrastructure-ansible-main/
+echo "✓ Temporary files removed."
+
+# Step 10: Optional: Uninstall system packages
+echo "[10/12] Checking for system packages..."
+read -p "Do you want to remove installed system packages (ansible, python3-kubernetes, kubectl, helm)? (y/n): " remove_packages
+if [[ "$remove_packages" =~ ^[Yy]$ ]]; then
+  apt remove -y ansible python3-kubernetes kubectl helm
+  echo "✓ System packages removed."
+else
+  echo "Skipping system packages removal."
+fi
+
+# Step 11: Clean orphaned package dependencies
+echo "[11/12] Cleaning orphaned package dependencies..."
+apt autoremove -y
+echo "✓ Orphaned package dependencies cleaned."
+
+# Step 12: Reset IP tables rules
+echo "[12/12] Resetting IP tables rules..."
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+echo "✓ IP tables rules reset."
+
+echo
+echo "Cleanup completed successfully!"
+echo "Your system has been restored to a state close to before the edge-infrastructure-ansible installation."
+echo "You may need to reboot your system for all changes to take effect."
+echo 


### PR DESCRIPTION
The issue for prometheus dashboard (error 404) is solved by adding a separate ingress for prometheus.
The issue for kubevirt installation is solved. It was due to the installation of a prerequisite in Ubuntu 24
A script for cleanup the whole installations is added with the corresponding manual in README.md file below the "automatic installation"